### PR TITLE
Pal 340 refactor clone method in User and UserId

### DIFF
--- a/src/main/java/uk/gov/gchq/palisade/User.java
+++ b/src/main/java/uk/gov/gchq/palisade/User.java
@@ -44,7 +44,7 @@ import static java.util.Objects.requireNonNull;
         include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = "class"
 )
-public class User implements Cloneable {
+public class User {
     private UserId userId;
 
     private Set<String> roles = new HashSet<>();

--- a/src/main/java/uk/gov/gchq/palisade/User.java
+++ b/src/main/java/uk/gov/gchq/palisade/User.java
@@ -61,7 +61,7 @@ public class User implements Cloneable {
      * Constructs a clone of the {@link User}.
      * @param user the {@link User} that will be cloned.
      */
-    User(User user) {
+    User(final User user) {
         userId = user.getUserId();
         roles = user.getRoles();
         auths = user.getAuths();

--- a/src/main/java/uk/gov/gchq/palisade/User.java
+++ b/src/main/java/uk/gov/gchq/palisade/User.java
@@ -51,6 +51,23 @@ public class User implements Cloneable {
     private Set<String> auths = new HashSet<>();
 
     /**
+     * Constructs an empty {@link User}.
+     */
+    public User() {
+        //no-args constructor needed for serialization only
+    }
+
+    /**
+     * Constructs a clone of the {@link User}.
+     * @param user the {@link User} that will be cloned.
+     */
+    User(User user) {
+        userId = user.getUserId();
+        roles = user.getRoles();
+        auths = user.getAuths();
+    }
+
+    /**
      * Sets the userId to a {@link UserId} with the given userId string.
      *
      * @param userId the unique user ID string.
@@ -176,19 +193,6 @@ public class User implements Cloneable {
         requireNonNull(roles, "Cannot add null roles.");
         this.roles.addAll(roles);
         return this;
-    }
-
-    public User clone() {
-        User clone;
-        try {
-            clone = (User) super.clone();
-        } catch (final CloneNotSupportedException e) {
-            clone = new User();
-        }
-        clone.userId(getUserId().clone());
-        clone.roles(getRoles());
-        clone.auths(getAuths());
-        return clone;
     }
 
     @Override

--- a/src/main/java/uk/gov/gchq/palisade/UserId.java
+++ b/src/main/java/uk/gov/gchq/palisade/UserId.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * A {@link UserId} uniquely identifies a {@link uk.gov.gchq.palisade.User}.
  */
-public class UserId implements Cloneable {
+public class UserId {
 
     private String id;
 

--- a/src/main/java/uk/gov/gchq/palisade/UserId.java
+++ b/src/main/java/uk/gov/gchq/palisade/UserId.java
@@ -39,7 +39,7 @@ public class UserId implements Cloneable {
      * Constructs a clone of the {@link UserId}.
      * @param userId the {@link UserId} that will be cloned.
      */
-    UserId(UserId userId) {
+    UserId(final UserId userId) {
         id = userId.getId();
     }
 

--- a/src/main/java/uk/gov/gchq/palisade/UserId.java
+++ b/src/main/java/uk/gov/gchq/palisade/UserId.java
@@ -36,6 +36,14 @@ public class UserId implements Cloneable {
     }
 
     /**
+     * Constructs a clone of the {@link UserId}.
+     * @param userId the {@link UserId} that will be cloned.
+     */
+    UserId(UserId userId) {
+        id = userId.getId();
+    }
+
+    /**
      * Updates the id of the UserID
      *
      * @param id a non null String representing the id of the user
@@ -54,17 +62,6 @@ public class UserId implements Cloneable {
     public String getId() {
         Objects.requireNonNull(id, "The UserId id field has not been initialised.");
         return id;
-    }
-
-    public UserId clone() {
-        UserId clone;
-        try {
-            clone = (UserId) super.clone();
-        } catch (final CloneNotSupportedException e) {
-            clone = new UserId();
-        }
-        clone.id = id;
-        return clone;
     }
 
     @Override


### PR DESCRIPTION
Removed the clone method from the classes and implemented a clone constructor method.
The `implements Cloneable` has been removed from the classes as well.