### PR TITLE
PAL-651 added 'implements serializable' for cacheable objects

### DIFF
--- a/src/main/java/uk/gov/gchq/palisade/User.java
+++ b/src/main/java/uk/gov/gchq/palisade/User.java
@@ -19,6 +19,7 @@ package uk.gov.gchq.palisade;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
@@ -44,7 +45,7 @@ import static java.util.Objects.requireNonNull;
         include = JsonTypeInfo.As.EXISTING_PROPERTY,
         property = "class"
 )
-public class User {
+public class User implements Serializable {
 
     private UserId userId;
     private Set<String> roles = new HashSet<>();

--- a/src/main/java/uk/gov/gchq/palisade/UserId.java
+++ b/src/main/java/uk/gov/gchq/palisade/UserId.java
@@ -16,6 +16,7 @@
 
 package uk.gov.gchq.palisade;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -24,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * A {@link UserId} uniquely identifies a {@link User}.
  */
-public class UserId {
+public class UserId implements Serializable {
 
     private String id;
 


### PR DESCRIPTION
Redis requires objects in cache to be marked as Serializable, no implementation required as the interface is just used as a tag of sorts