### PR TITLE
Pal 822 jvm example pipeline

### DIFF
--- a/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
+++ b/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
@@ -107,17 +107,17 @@ public class FileResourceBuilder extends ResourceBuilder {
         URI absoluteResourceId = resourceUri;
 
         // Check if the path is not complete, and therefore needs enriching to locate resources
-        if (!Path.of(resourceUri.getScheme()).isAbsolute()) {
+        if (!Path.of(resourceUri.getSchemeSpecificPart()).isAbsolute()) {
             File localResource = new File(resourceUri.getSchemeSpecificPart());
             String path;
             try {
                 path = localResource.getCanonicalPath();
             } catch (IOException e) {
-                LOGGER.error("Unable to get the Canonical path value", e);
+                LOGGER.warn("Unable to get the Canonical path value", e);
                 path = localResource.getAbsolutePath();
             }
 
-            // Check if the resource is a directory and if the path ends with a "/"
+            // Check if the resource is a directory and the path does not end with a "/"
             if (localResource.isDirectory() && !path.endsWith("/")) {
                 path += "/";
             }

--- a/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
+++ b/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
@@ -104,7 +104,12 @@ public class FileResourceBuilder extends ResourceBuilder {
 
     @Override
     public Resource build(final URI resourceUri) {
-        return filesystemScheme(resourceUri);
+        String path = Path.of(resourceUri.getSchemeSpecificPart()).toAbsolutePath().toString();
+        URI absoluteResourceId = UriBuilder.create(resourceUri)
+                .withoutScheme().withoutAuthority()
+                .withPath(path)
+                .withoutQuery().withoutFragment();
+        return filesystemScheme(absoluteResourceId);
     }
 
     @Override

--- a/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
+++ b/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
@@ -104,11 +104,24 @@ public class FileResourceBuilder extends ResourceBuilder {
 
     @Override
     public Resource build(final URI resourceUri) {
-        String path = Path.of(resourceUri.getSchemeSpecificPart()).toAbsolutePath().toString();
-        URI absoluteResourceId = UriBuilder.create(resourceUri)
-                .withoutScheme().withoutAuthority()
-                .withPath(path)
-                .withoutQuery().withoutFragment();
+        URI absoluteResourceId = resourceUri;
+        if (!Path.of(resourceUri.getScheme()).isAbsolute()) {
+            File localResourece = new File(resourceUri.getSchemeSpecificPart());
+            String path;
+            try {
+                path = localResourece.getCanonicalPath();
+            } catch (Exception e) {
+                path = localResourece.getAbsolutePath();
+            }
+
+            if (localResourece.isDirectory() && !path.endsWith("/")) {
+                path += "/";
+            }
+            absoluteResourceId = UriBuilder.create(resourceUri)
+                    .withoutScheme().withoutAuthority()
+                    .withPath(path)
+                    .withoutQuery().withoutFragment();
+        }
         return filesystemScheme(absoluteResourceId);
     }
 

--- a/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
+++ b/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
@@ -110,7 +110,8 @@ public class FileResourceBuilder extends ResourceBuilder {
             String path;
             try {
                 path = localResourece.getCanonicalPath();
-            } catch (Exception e) {
+            } catch (IOException e) {
+                LOGGER.error("Unable to get the Canonical path value", e);
                 path = localResourece.getAbsolutePath();
             }
 

--- a/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
+++ b/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
@@ -106,7 +106,7 @@ public class FileResourceBuilder extends ResourceBuilder {
     public Resource build(final URI resourceUri) {
         URI absoluteResourceId = resourceUri;
 
-        // Check if the path is not absolute
+        // Check if the path is not complete, and therefore needs enriching to locate resources
         if (!Path.of(resourceUri.getScheme()).isAbsolute()) {
             File localResource = new File(resourceUri.getSchemeSpecificPart());
             String path;

--- a/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
+++ b/src/main/java/uk/gov/gchq/palisade/util/FileResourceBuilder.java
@@ -105,17 +105,20 @@ public class FileResourceBuilder extends ResourceBuilder {
     @Override
     public Resource build(final URI resourceUri) {
         URI absoluteResourceId = resourceUri;
+
+        // Check if the path is not absolute
         if (!Path.of(resourceUri.getScheme()).isAbsolute()) {
-            File localResourece = new File(resourceUri.getSchemeSpecificPart());
+            File localResource = new File(resourceUri.getSchemeSpecificPart());
             String path;
             try {
-                path = localResourece.getCanonicalPath();
+                path = localResource.getCanonicalPath();
             } catch (IOException e) {
                 LOGGER.error("Unable to get the Canonical path value", e);
-                path = localResourece.getAbsolutePath();
+                path = localResource.getAbsolutePath();
             }
 
-            if (localResourece.isDirectory() && !path.endsWith("/")) {
+            // Check if the resource is a directory and if the path ends with a "/"
+            if (localResource.isDirectory() && !path.endsWith("/")) {
                 path += "/";
             }
             absoluteResourceId = UriBuilder.create(resourceUri)

--- a/src/main/java/uk/gov/gchq/palisade/util/ResourceBuilder.java
+++ b/src/main/java/uk/gov/gchq/palisade/util/ResourceBuilder.java
@@ -16,8 +16,12 @@
 
 package uk.gov.gchq.palisade.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import uk.gov.gchq.palisade.resource.Resource;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ServiceLoader;
@@ -28,6 +32,7 @@ import java.util.ServiceLoader.Provider;
  */
 public abstract class ResourceBuilder {
     private static final ServiceLoader<ResourceBuilder> LOADER = ServiceLoader.load(ResourceBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceBuilder.class);
 
     /**
      * Clears this loader's provider cache so that all providers will be reloaded.
@@ -82,7 +87,8 @@ public abstract class ResourceBuilder {
                     .withoutQuery()
                     .withoutFragment();
             return build(normal);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
+            LOGGER.error("Unable to build a normal URI", e);
             return build(uri);
         }
     }

--- a/src/main/java/uk/gov/gchq/palisade/util/ResourceBuilder.java
+++ b/src/main/java/uk/gov/gchq/palisade/util/ResourceBuilder.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 
 import uk.gov.gchq.palisade.resource.Resource;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ServiceLoader;

--- a/src/main/java/uk/gov/gchq/palisade/util/ResourceBuilder.java
+++ b/src/main/java/uk/gov/gchq/palisade/util/ResourceBuilder.java
@@ -74,13 +74,17 @@ public abstract class ResourceBuilder {
      * @return a newly created resource with the id of the uri.
      */
     public Resource buildNormal(final URI uri) {
-        URI normal = UriBuilder.create(uri)
-                .withoutScheme()
-                .withoutAuthority()
-                .withoutPath()
-                .withoutQuery()
-                .withoutFragment();
-        return build(normal);
+        try {
+            URI normal = UriBuilder.create(uri)
+                    .withoutScheme()
+                    .withoutAuthority()
+                    .withoutPath()
+                    .withoutQuery()
+                    .withoutFragment();
+            return build(normal);
+        } catch (Exception e) {
+            return build(uri);
+        }
     }
 
     /**


### PR DESCRIPTION
Updated ResourceBuilder and FileResourceBuilder so URIs can be used to create resources properly for prepopulation in the resource and policy services.